### PR TITLE
Fix card issue caused by unreliable JQuery.animate

### DIFF
--- a/statdrawer.js
+++ b/statdrawer.js
@@ -205,11 +205,12 @@ class StatDrawer extends Application {
                     } else {
                         element.off('click');
                     }
+                    element.animate({
+                        width: originalWidth,
+                        'margin-left': 0
+                    }, animationTime);
                 }
-            }).animate({
-                width: originalWidth,
-                'margin-left': 0
-            }, animationTime);
+            });
     }
 
     async updateChatMessage() {


### PR DESCRIPTION
$JQuery.animate() is not always returning the JQuery element, which causes an error to be thrown when the subsequent call to .animate() occurs. This change simply moves the subsequent animation into the completion block of the first animation.